### PR TITLE
GitHub Pages deploy workflow for backward-compatible dist URLs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site/dist _site/examples
+          cp packages/js/dist/custom-widget.js    _site/dist/
+          cp packages/js/dist/custom-widget.min.js _site/dist/
+          cp packages/js/dist/custom-widget.css    _site/dist/
+          cp packages/js/dist/custom-widget.min.css _site/dist/
+          cp packages/js/examples/*.html           _site/examples/
+
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,9 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that deploys to GitHub Pages on push to master
- Copies `packages/js/dist/` files to `/dist/` at the site root, preserving the old URL structure
- Also copies `packages/js/examples/` to `/examples/` for the same reason

After merging the monorepo PRs (#7 and #8), the dist files move from the repo root to `packages/js/dist/`. Without this workflow, the existing GitHub Pages URLs (`/dist/custom-widget.min.js`, `/dist/custom-widget.min.css`, etc.) would break.

## Required manual step
The repo Pages source must be switched from "Deploy from a branch" (legacy) to "GitHub Actions" in **Settings > Pages > Build and deployment > Source**. The workflow handles everything else.

## Test plan
- [ ] Switch Pages source to "GitHub Actions" in repo settings
- [ ] Merge PRs #7 and #8 into master
- [ ] Verify the deploy workflow runs and succeeds
- [ ] Confirm `https://tago-io.github.io/custom-widget/dist/custom-widget.min.js` returns the built SDK
- [ ] Confirm `https://tago-io.github.io/custom-widget/dist/custom-widget.min.css` returns the stylesheet
- [ ] Confirm `https://tago-io.github.io/custom-widget/examples/basic-widget.html` loads correctly